### PR TITLE
enable backspace and escape, disable overlay

### DIFF
--- a/static/js/barcode.js
+++ b/static/js/barcode.js
@@ -8,6 +8,13 @@ function showBarcode(text) {
     document.getElementById('barcodeContent').textContent = text
 }
 
+function hideBarcode() {
+    if (barcodeShown) {
+        document.getElementById('barcode').classList.remove('shown')
+    }
+    return document.getElementById('barcodeContent').textContent
+}
+
 function barcodeKeyPress(event) {
     var key = String.fromCharCode(event.charCode)
     var focused = document.activeElement
@@ -16,8 +23,8 @@ function barcodeKeyPress(event) {
     } else if (document.querySelector) {
         focused = document.querySelector(":focus")
     }
-    if (focused == null || focused.tagName != "INPUT") {
-        if (event.keyCode === 13) {
+    if ( focused == null || focused.tagName != "INPUT" ) {
+        if ( event.keyCode === 13 ) {
             var input = document.getElementById('barcodeInput')
             if (input) {
                 input.setAttribute('value', barcodeBuf)
@@ -25,6 +32,15 @@ function barcodeKeyPress(event) {
                 return
             }
             barcodeBuf = ""
+            event.preventDefault()
+        } else if ( event.keyCode === 27 ){
+            barcodeBuf=hideBarcode()
+            event.preventDefault()
+        } else if ( event.keyCode === 9 ){
+            barcodeBuf = barcodeBuf.substring( 0, barcodeBuf.length - 1  )
+            if ( barcodeBuf.length <= 0 ) {
+                barcodeBuf=hideBarcode()
+            }
             event.preventDefault()
         } else {
             barcodeBuf += key


### PR DESCRIPTION
when either escape is used or barcode is empty after hitting backspace